### PR TITLE
fix "stripos(): Passing null to parameter warning" when content-type is null

### DIFF
--- a/src/MultipartFormDataParser.php
+++ b/src/MultipartFormDataParser.php
@@ -142,7 +142,7 @@ class MultipartFormDataParser
     public function parse(Request $request): Request
     {
         $contentType = $request->headers->get('CONTENT_TYPE');
-        if (stripos($contentType, 'multipart/form-data') === false) {
+        if (is_null($contentType) || stripos($contentType, 'multipart/form-data') === false) {
             return $request;
         }
         if (!preg_match('/boundary=(.*)$/is', $contentType, $matches)) {


### PR DESCRIPTION
Fixes warning when the content type is null (f.e. if it was not passed in the request headers for some reason).
![image](https://user-images.githubusercontent.com/2050582/224644393-c1ba1b8b-90a7-4749-ac68-b1cac447b911.png)
