### PR TITLE
PHP 8.4 Compatibility

### DIFF
--- a/src/MultipartFormDataParser.php
+++ b/src/MultipartFormDataParser.php
@@ -259,7 +259,7 @@ class MultipartFormDataParser
      * @param  int|null  $error the error associated with the uploaded file.
      * @return \Symfony\Component\HttpFoundation\File\UploadedFile|object new uploaded file instance.
      */
-    protected function createUploadedFile(string $tempFilename, string $clientFilename, string $clientMediaType = null, int $error = null)
+    protected function createUploadedFile(string $tempFilename, string $clientFilename, ?string $clientMediaType = null, ?int $error = null)
     {
         return new UploadedFile($tempFilename, $clientFilename, $clientMediaType, $error, true);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | fixes explicit nullable


```
Deprecated: Illuminatech\MultipartMiddleware\MultipartFormDataParser::createUploadedFile(): Implicitly marking parameter $clientMediaType as nullable is deprecated, the explicit nullable type must be used instead
Deprecated: Illuminatech\MultipartMiddleware\MultipartFormDataParser::createUploadedFile(): Implicitly marking parameter $error as nullable is deprecated, the explicit nullable type must be used instead
```